### PR TITLE
Convert Output Report to docx

### DIFF
--- a/.github/workflows/pandoc.yaml
+++ b/.github/workflows/pandoc.yaml
@@ -1,0 +1,35 @@
+---
+name: Convert Markdown to docx
+
+on: workflow_dispatch
+
+jobs:
+    convert_via_pandoc:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Run Pandoc to convert Markdown to docx
+              uses: docker://pandoc/extra
+              with:
+                args: output_report.md -o report.docx -f markdown -t docx
+            
+            - name: Upload PDF report
+              uses: actions/upload-artifact@v4
+              with:
+                name: report.docx
+                path: report.docx
+
+            - name: Set Timestamp
+              id: timestamp
+              run: echo "TIMESTAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_ENV
+
+            - name: Create Release
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                gh release create "tag-$TIMESTAMP" report.docx \
+                --title "Output Report: $TIMESTAMP" \
+                --notes "Word Document version of output_report.pdf (docx)" \
+                --repo ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The repository also contains a range of housekeeping documentation to fit ONS de
 
 A write-up of the findings and recommendations are available within the [Output Report](./output_report.md). This report includes the general experience of using GitHub Codespaces, the benefits and drawbacks of using Codespaces, and recommendations for future use.
 
+This report is also available in MS Word Format (`.docx`). This file is available within the repository's releases.
+
+*(See [`pandoc.yaml`](./.github/workflows/pandoc.yaml) for how this gets generated).*
+
 ## Getting Started
 
 ### Codespace Running (Recommended)

--- a/output_report.md
+++ b/output_report.md
@@ -1,6 +1,6 @@
 # GitHub Codespaces Proof of Concept: Findings and Recommendations
 
-## TL;DR
+## Executive Summary
 
 This report summarizes the experience of using GitHub Codespaces for a proof of concept project. It includes the benefits and drawbacks of using Codespaces, as well as recommendations for future use.
 
@@ -13,7 +13,7 @@ To summarise, the main findings are:
 ## Contents
 
 - [GitHub Codespaces Proof of Concept: Findings and Recommendations](#github-codespaces-proof-of-concept-findings-and-recommendations)
-  - [TL;DR](#tldr)
+  - [Executive Summary](#executive-summary)
   - [Contents](#contents)
   - [General Experience](#general-experience)
   - [Key Findings](#key-findings)


### PR DESCRIPTION
# Overview

This PR adds the functionality to convert the output report from markdown to docx.

# Related Issue / Ticket

N/A

# Changes

- New `pandoc.yaml` action to generate the docx.
- Rename TLDR section to Executive Summary within the report.

# Why This Change is Necessary

Requested by Dom.

# How to Test

N/A

# Checklist

Please fill in the below before submitting your PR. All items should be completed and checked.

- [x] Self-review performed.
- [x] In code annotations used where necessary.
- [x] Documentation updated/created.
- [x] Testing updated/created and passing.
- [x] Linting passes.
- [x] Contributing Guidance read, understood and adhered to.
